### PR TITLE
Return single quoted html code

### DIFF
--- a/restApi/src/main/scala/de/htwberlin/f4/wikiplag/rest/services/CreateAnalyseBeanService.scala
+++ b/restApi/src/main/scala/de/htwberlin/f4/wikiplag/rest/services/CreateAnalyseBeanService.scala
@@ -33,7 +33,7 @@ object CreateAnalyseBeanService {
     plagIndices = List(0) ::: plagIndices ::: List(rawInputText.length)
     var rawTextSplit = Functions.SplitByMultipleIndices(plagIndices, rawInputText)
 
-    var span ="""<span id="%d" class="input_plag">%s</span>"""
+    var span ="""<span id='%d' class='input_plag'>%s</span>"""
 
     model.tagged_input_text = rawTextSplit.zipWithIndex.map(x => {
       //even ones are plagiarisms


### PR DESCRIPTION
Es gab Probleme mit der Verarbeitung von doppelten Anführungszeichen in HTML-Quelltext im Frontend.